### PR TITLE
Use existing nodes service for metrics

### DIFF
--- a/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+++ b/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
@@ -51,12 +51,12 @@ spec:
             nodes:
               format: int32
               type: integer
-            optimizeKernelParams:
-              type: boolean
-            prometheusServiceMonitorLabels:
+            nodesServiceLabels:
               additionalProperties:
                 type: string
               type: object
+            optimizeKernelParams:
+              type: boolean
             prometheusSupport:
               type: boolean
             racks:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/instaclustr/cassandra-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
-	github.com/coreos/prometheus-operator v0.32.0 // indirect
+	github.com/coreos/prometheus-operator v0.32.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/go-resty/resty/v2 v2.0.0

--- a/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
@@ -8,25 +8,25 @@ import (
 // CassandraDataCenterSpec defines the desired state of CassandraDataCenter
 // +k8s:openapi-gen=true
 type CassandraDataCenterSpec struct {
-	Nodes                          int32                         `json:"nodes,omitempty"`
-	CassandraImage                 string                        `json:"cassandraImage,omitempty"`
-	SidecarImage                   string                        `json:"sidecarImage,omitempty"`
-	Racks                          []Rack                        `json:"racks,omitempty"`
-	ImagePullPolicy                v1.PullPolicy                 `json:"imagePullPolicy,omitempty"`
-	ImagePullSecrets               []v1.LocalObjectReference     `json:"imagePullSecrets,omitempty"`
-	BackupSecretVolumeSource       *v1.SecretVolumeSource        `json:"backupSecretVolumeSource,omitempty"`
-	RestoreFromBackup              string                        `json:"restoreFromBackup,omitempty"`
-	UserSecretVolumeSource         *v1.SecretVolumeSource        `json:"userSecretVolumeSource,omitempty"`
-	UserConfigMapVolumeSource      *v1.ConfigMapVolumeSource     `json:"userConfigMapVolumeSource,omitempty"`
-	Resources                      *v1.ResourceRequirements      `json:"resources,omitempty"`
-	DataVolumeClaimSpec            *v1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec,omitempty"`
-	OptimizeKernelParams           bool                          `json:"optimizeKernelParams,omitempty"`
-	PrometheusSupport              bool                          `json:"prometheusSupport,omitempty"`
-	PrometheusServiceMonitorLabels map[string]string             `json:"prometheusServiceMonitorLabels,omitempty"`
-	SidecarEnv                     []v1.EnvVar                   `json:"sidecarEnv,omitempty"`
-	CassandraEnv                   []v1.EnvVar                   `json:"cassandraEnv,omitempty"`
-	ServiceAccountName             string                        `json:"serviceAccountName,omitempty"`
-	FSGroup                        int64                         `json:"fsGroup,omitempty"`
+	Nodes                     int32                         `json:"nodes,omitempty"`
+	CassandraImage            string                        `json:"cassandraImage,omitempty"`
+	SidecarImage              string                        `json:"sidecarImage,omitempty"`
+	Racks                     []Rack                        `json:"racks,omitempty"`
+	ImagePullPolicy           v1.PullPolicy                 `json:"imagePullPolicy,omitempty"`
+	ImagePullSecrets          []v1.LocalObjectReference     `json:"imagePullSecrets,omitempty"`
+	BackupSecretVolumeSource  *v1.SecretVolumeSource        `json:"backupSecretVolumeSource,omitempty"`
+	RestoreFromBackup         string                        `json:"restoreFromBackup,omitempty"`
+	UserSecretVolumeSource    *v1.SecretVolumeSource        `json:"userSecretVolumeSource,omitempty"`
+	UserConfigMapVolumeSource *v1.ConfigMapVolumeSource     `json:"userConfigMapVolumeSource,omitempty"`
+	Resources                 *v1.ResourceRequirements      `json:"resources,omitempty"`
+	DataVolumeClaimSpec       *v1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec,omitempty"`
+	OptimizeKernelParams      bool                          `json:"optimizeKernelParams,omitempty"`
+	PrometheusSupport         bool                          `json:"prometheusSupport,omitempty"`
+	NodesServiceLabels        map[string]string             `json:"nodesServiceLabels,omitempty"`
+	SidecarEnv                []v1.EnvVar                   `json:"sidecarEnv,omitempty"`
+	CassandraEnv              []v1.EnvVar                   `json:"cassandraEnv,omitempty"`
+	ServiceAccountName        string                        `json:"serviceAccountName,omitempty"`
+	FSGroup                   int64                         `json:"fsGroup,omitempty"`
 }
 
 // CassandraDataCenterStatus defines the observed state of CassandraDataCenter

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.deepcopy.go
@@ -311,8 +311,8 @@ func (in *CassandraDataCenterSpec) DeepCopyInto(out *CassandraDataCenterSpec) {
 		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PrometheusServiceMonitorLabels != nil {
-		in, out := &in.PrometheusServiceMonitorLabels, &out.PrometheusServiceMonitorLabels
+	if in.NodesServiceLabels != nil {
+		in, out := &in.NodesServiceLabels, &out.NodesServiceLabels
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
@@ -400,7 +400,7 @@ func schema_pkg_apis_cassandraoperator_v1alpha1_CassandraDataCenterSpec(ref comm
 							Format: "",
 						},
 					},
-					"prometheusServiceMonitorLabels": {
+					"nodesServiceLabels": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{

--- a/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -163,7 +163,7 @@ func (r *ReconcileCassandraDataCenter) Reconcile(request reconcile.Request) (rec
 	}
 
 	if rctx.cdc.Spec.PrometheusSupport {
-		if err := createOrUpdatePrometheusServiceMonitor(rctx); err != nil {
+		if err := createOrUpdatePrometheusServiceMonitor(nodesService); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/cassandradatacenter/metadata.go
+++ b/pkg/controller/cassandradatacenter/metadata.go
@@ -20,16 +20,6 @@ func DataCenterLabels(cdc *cassandraoperatorv1alpha1.CassandraDataCenter) map[st
 	}
 }
 
-func PrometheusLabels(cdc *cassandraoperatorv1alpha1.CassandraDataCenter) map[string]string {
-	// Fetch cdc labels
-	labels := DataCenterLabels(cdc)
-	// Add prometheus labels if defined
-	for label, val := range cdc.Spec.PrometheusServiceMonitorLabels {
-		labels[label] = val
-	}
-	return labels
-}
-
 func RackLabels(cdc *cassandraoperatorv1alpha1.CassandraDataCenter, rack *cluster.Rack) map[string]string {
 	// Fetch cdc labels
 	rackLabels := DataCenterLabels(cdc)


### PR DESCRIPTION
This PR suggests an improvement on top of https://github.com/instaclustr/cassandra-operator/pull/294 in which we keep the metrics port on the `-nodes` service rather than create a separate service just for metrics.